### PR TITLE
Added docker configuration + tested it in parallel using postman

### DIFF
--- a/UniqueIDGenerator/Dockerfile
+++ b/UniqueIDGenerator/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17
+VOLUME /tmp
+EXPOSE 8080
+ARG JAR_FILE=target/*.jar
+ADD ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
I have tested it in using postman run collection and was able to see 2 subsequent IDs being generated proving that 2 ids are generated in same milliseconds. 